### PR TITLE
Basic integration with Immersion

### DIFF
--- a/Wholly.lua
+++ b/Wholly.lua
@@ -780,6 +780,12 @@ self.currentFrame = com_mithrandir_whollyFrame
 					self:_SetupWorldMapWhollyButton()
 
 
+if ImmersionContentFrame then
+	QuestFrame = ImmersionContentFrame
+	com_mithrandir_whollyQuestInfoBuggedFrame:SetParent(QuestFrame)
+	com_mithrandir_whollyBreadcrumbFrame:SetParent(QuestFrame)
+end
+
 -- if the UI panel disappears (maximized WorldMapFrame) we need to change parents
 UIParent:HookScript("OnHide", function()
 self.tooltip:SetParent(WorldMapFrame);

--- a/Wholly.toc
+++ b/Wholly.toc
@@ -4,7 +4,7 @@
 ## Notes: Shows quest database and map pins
 ## Version: 088
 ## Dependencies: Grail
-## OptionalDeps: LibStub, LibDataBroker, TomTom, Gatherer, Questie
+## OptionalDeps: LibStub, LibDataBroker, TomTom, Gatherer, Questie, Immersion
 ## SavedVariablesPerCharacter: WhollyDatabase
 
 Wholly.lua


### PR DESCRIPTION
This will allow elements that are intended to show on the QuestFrame to display in [Immersion](https://www.curseforge.com/wow/addons/immersion)'s version of the quest frame. I've tested that the code works both with an without Immersion enabled.

![Screenshot](https://user-images.githubusercontent.com/835767/205589967-b694b4ec-c8ac-44ec-82d5-667e3d528dac.png)

I know very little about addon development, but this implementation appears to be functional and restores functionality that I'd lost when I first started using Immersion a couple years ago.

This addresses my feature request in issue #53.